### PR TITLE
Use submodules option in checkout action for codeql

### DIFF
--- a/.github/workflows/buildscript.sh
+++ b/.github/workflows/buildscript.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-git submodule update --init --recursive
 bazel build --config=libc++ -c opt eigenmath:all
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-
+      with:
+        submodules: 'true'
+  
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
Use submodules option from the checkout action to fetch submodules, which appears to be the way to do this (https://github.com/actions/checkout).