### PR TITLE
Rewired genit dependency to public release, removed submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/x-edr-genit"]
-	path = third_party/x-edr-genit
-	url = https://github.com/theteamatx/x-edr-genit.git

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,6 +25,7 @@ http_archive(
 http_archive(
     name = "eigen",
     build_file = "//third_party:eigen.BUILD",
+    sha256 = "8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72",
     url = "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz",
     strip_prefix="eigen-3.4.0",
 )
@@ -53,14 +54,13 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-#git_repository(
-#    name = "genit",
-#    remote = "https://github.com/theteamatx/x-edr-genit.git",
-#    branch = "main"
-#)
-
-local_repository(
-    name = "genit",
-    path = "third_party/x-edr-genit",
+# GenIt
+_GENIT_VERSION = "1.0.0"
+http_archive(
+    name = "x_edr_genit",
+    sha256 = "ab1bbb15ecbe86c5c3888a12c56fe88fac416f2f305acaf1bbf7f68c3d429851",
+    strip_prefix = "x-edr-genit-%s" % _GENIT_VERSION,
+    urls = [
+        "https://github.com/theteamatx/x-edr-genit/archive/refs/tags/v%s.tar.gz" % _GENIT_VERSION,
+    ],
 )
-

--- a/eigenmath/BUILD
+++ b/eigenmath/BUILD
@@ -66,7 +66,7 @@ cc_library(
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
         "@eigen",
-        "@genit//genit:iterators",
+        "@x_edr_genit//genit:iterators",
     ],
 )
 
@@ -132,7 +132,7 @@ cc_library(
         ":eigenmath",
         "@com_google_googletest//:gtest",
         "@eigen",
-        "@genit//genit:iterators",
+        "@x_edr_genit//genit:iterators",
     ],
 )
 


### PR DESCRIPTION
Rewired genit dependency to public release, removed submodule

Second attempt at https://github.com/theteamatx/x-edr-eigenmath/pull/12 but with signed commits (aarrggh!)